### PR TITLE
Enhance toolkit with 5G utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,13 @@ The script will sequentially:
 For a single entry point to these steps you can also use `rrc_toolkit.py` with different subcommands:
 
 ```bash
-python3 rrc_toolkit.py mobility   # run mobility scenarios
-python3 rrc_toolkit.py capture    # capture traces
-python3 rrc_toolkit.py analyze    # analyze data
-python3 rrc_toolkit.py visualize  # create visualizations
+python3 rrc_toolkit.py mobility    # run legacy mobility scenarios
+python3 rrc_toolkit.py capture     # capture traces
+python3 rrc_toolkit.py analyze     # analyze data with legacy scripts
+python3 rrc_toolkit.py visualize   # create visualizations
+python3 rrc_toolkit.py mobility5g  # run enhanced 5G mobility simulation
+python3 rrc_toolkit.py analyze5g   # analyze traces with enhanced analyzer
+python3 rrc_toolkit.py metrics     # collect performance metrics
 ```
 
 Each subcommand corresponds to one of the scripts in this repository but provides a consolidated interface.

--- a/rrc_toolkit.py
+++ b/rrc_toolkit.py
@@ -1,18 +1,27 @@
 import argparse
+import subprocess
 from ue_mobility_controller import UEMobilityController
 from rrc_trace_capture import RRCTraceCapture
 from rrc_trace_analyzer import RRCTraceAnalyzer
 from rrc_trace_visualizer import RRCTraceVisualizer
+from srsRAN_5G.srsRAN_5G import (
+    enhanced_ue_mobility_controller_v2,
+    enhanced_rrc_trace_analyzer,
+    enhanced_performance_metrics_collector,
+)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Unified entry point for mobility simulation and RRC tracing")
     subparsers = parser.add_subparsers(dest="command")
 
-    subparsers.add_parser("mobility", help="Run UE mobility scenarios")
+    subparsers.add_parser("mobility", help="Run UE mobility scenarios (legacy)")
     subparsers.add_parser("capture", help="Capture RRC traces")
-    subparsers.add_parser("analyze", help="Analyze captured traces")
+    subparsers.add_parser("analyze", help="Analyze captured traces (legacy)")
     subparsers.add_parser("visualize", help="Visualize analysis results")
+    subparsers.add_parser("mobility5g", help="Run enhanced 5G mobility simulation")
+    subparsers.add_parser("analyze5g", help="Analyze traces with enhanced analyzer")
+    subparsers.add_parser("metrics", help="Collect performance metrics")
 
     args = parser.parse_args()
 
@@ -28,6 +37,12 @@ def main() -> None:
     elif args.command == "visualize":
         visualizer = RRCTraceVisualizer()
         visualizer.run_visualization()
+    elif args.command == "mobility5g":
+        enhanced_ue_mobility_controller_v2.main()
+    elif args.command == "analyze5g":
+        enhanced_rrc_trace_analyzer.main()
+    elif args.command == "metrics":
+        enhanced_performance_metrics_collector.main()
     else:
         parser.print_help()
 

--- a/srsRAN_5G/__init__.py
+++ b/srsRAN_5G/__init__.py
@@ -1,0 +1,4 @@
+"""Helper package exposing enhanced srsRAN utilities."""
+
+from .srsRAN_5G import *
+

--- a/srsRAN_5G/srsRAN_5G/__init__.py
+++ b/srsRAN_5G/srsRAN_5G/__init__.py
@@ -1,0 +1,2 @@
+"""Enhanced simulation tools for srsRAN 5G."""
+


### PR DESCRIPTION
## Summary
- add package init files so Python can import 5G tools
- extend `rrc_toolkit.py` with subcommands for 5G mobility and analysis
- document new toolkit subcommands

## Testing
- `git status --short`
